### PR TITLE
handle no frontend_port for cross-origin header

### DIFF
--- a/src/http/http.go
+++ b/src/http/http.go
@@ -147,6 +147,11 @@ func (c *Cfg) getFile(resp http.ResponseWriter, req *http.Request) {
 }
 
 func setHeaders(resp http.ResponseWriter, host string, port string) http.ResponseWriter {
+    if port == "" {
+        resp.Header().Set("Access-Control-Allow-Origin", fmt.Sprintf("%s", host))
+    } else {
+        resp.Header().Set("Access-Control-Allow-Origin", fmt.Sprintf("%s:%s", host, port))
+    }
 	resp.Header().Set("Access-Control-Allow-Origin", fmt.Sprintf("%s:%s", host, port))
 	resp.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
 	resp.Header().Set("Access-Control-Allow-Headers", "Content-Type")


### PR DESCRIPTION
if no port is supplied (`port = ""`), a different format string is used

```
%s:%s => %s
```