### PR TITLE
use npm serve for serving the site

### DIFF
--- a/file-server-frontend/Dockerfile
+++ b/file-server-frontend/Dockerfile
@@ -2,7 +2,9 @@ FROM node:latest
 WORKDIR /app
 ENV PATH /app/node_modules/.bin:$PATH
 COPY package.json /app/package.json
+RUN npm install -g serve
 RUN npm install
 RUN npm install -g @angular/cli@7.3.9
 COPY . /app
-CMD ng serve --host 0.0.0.0
+RUN ng build
+CMD serve -s dist/file-server-frontend

--- a/src/http/http.go
+++ b/src/http/http.go
@@ -152,7 +152,6 @@ func setHeaders(resp http.ResponseWriter, host string, port string) http.Respons
     } else {
         resp.Header().Set("Access-Control-Allow-Origin", fmt.Sprintf("%s:%s", host, port))
     }
-	resp.Header().Set("Access-Control-Allow-Origin", fmt.Sprintf("%s:%s", host, port))
 	resp.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
 	resp.Header().Set("Access-Control-Allow-Headers", "Content-Type")
 	resp.Header().Set("Access-Control-Allow-Credentials", "true")


### PR DESCRIPTION
the commit uses the npm package `serve` for hosting the website.
It includes a static build `ng build` of the site prior to hosting.

I aswell changed sth. on the http.go, as I messed sth. up last time on my diff for setting the Control-Allow-Origin.